### PR TITLE
use RequiredArgsConstructor to replace autowired

### DIFF
--- a/src/main/java/com/supportsystem/application/controllers/AppUserController.java
+++ b/src/main/java/com/supportsystem/application/controllers/AppUserController.java
@@ -1,40 +1,29 @@
 package com.supportsystem.application.controllers;
 
-import java.util.List;
-
 import com.supportsystem.application.domains.AppUser;
 import com.supportsystem.application.request.dtos.UserRequestDTO;
+import com.supportsystem.application.response.dtos.UserResponseDTO;
+import com.supportsystem.application.services.AppUserService;
 import com.supportsystem.application.services.UserRegistrationService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Description;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import com.supportsystem.application.response.dtos.UserResponseDTO;
-import com.supportsystem.application.services.AppUserService;
-
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
 
 @Slf4j
 @RestController
 @RequestMapping("/users")
+@RequiredArgsConstructor
 public class AppUserController {
 
-
-    @Autowired
-    private AppUserService userService;
-
-    @Autowired
-    private UserRegistrationService userRegistrationService;
+    private final AppUserService userService;
+    private final UserRegistrationService userRegistrationService;
 
     @PostMapping("/register")
     @Description(value = "register a new user")

--- a/src/main/java/com/supportsystem/application/controllers/AuthController.java
+++ b/src/main/java/com/supportsystem/application/controllers/AuthController.java
@@ -1,15 +1,17 @@
 package com.supportsystem.application.controllers;
 
 import com.supportsystem.application.security.JwtTokenUtil;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.HashMap;
@@ -18,13 +20,11 @@ import java.util.Map;
 @Slf4j
 @RestController
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
-    @Autowired
-    private AuthenticationManager authenticationManager;
-
-    @Autowired
-    private JwtTokenUtil jwtTokenUtil;
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenUtil jwtTokenUtil;
 
     @PostMapping("/login")
     public Map<String, String> login(@RequestParam String username, @RequestParam String password) {

--- a/src/main/java/com/supportsystem/application/controllers/TicketController.java
+++ b/src/main/java/com/supportsystem/application/controllers/TicketController.java
@@ -24,17 +24,16 @@ import com.supportsystem.application.request.dtos.TicketRequestDTO;
 import com.supportsystem.application.services.TicketService;
 
 import lombok.extern.slf4j.Slf4j;
+import lombok.RequiredArgsConstructor;
 
 @Slf4j
 @RestController
 @RequestMapping("/tickets")
+@RequiredArgsConstructor
 public class TicketController {
 
-    @Autowired
-    private TicketService ticketService;
-
-    @Autowired
-    private TicketCommentService ticketCommentService;
+    private final TicketService ticketService;
+    private final TicketCommentService ticketCommentService;
 
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @Description(value = "returns all tickets")

--- a/src/main/java/com/supportsystem/application/security/JwtFilter.java
+++ b/src/main/java/com/supportsystem/application/security/JwtFilter.java
@@ -1,31 +1,27 @@
 package com.supportsystem.application.security;
 
 import com.supportsystem.application.services.AppUserService;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import java.io.IOException;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
+
     private final JwtTokenUtil jwtTokenUtil;
     private final AppUserService userService;
-
-    @Autowired
-    public JwtFilter(JwtTokenUtil jwtTokenUtil, AppUserService userService) {
-        this.jwtTokenUtil = jwtTokenUtil;
-        this.userService = userService;
-    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/src/main/java/com/supportsystem/application/services/AppUserServiceImpl.java
+++ b/src/main/java/com/supportsystem/application/services/AppUserServiceImpl.java
@@ -1,16 +1,14 @@
 package com.supportsystem.application.services;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
+import com.supportsystem.application.domains.AppUser;
 import com.supportsystem.application.exceptions.ResourceNotFoundException;
-import com.supportsystem.application.repositories.RoleRepository;
+import com.supportsystem.application.repositories.AppUserRepository;
 import com.supportsystem.application.request.dtos.UserRequestDTO;
+import com.supportsystem.application.response.dtos.UserResponseDTO;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -19,22 +17,18 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import com.supportsystem.application.domains.AppUser;
-import com.supportsystem.application.repositories.AppUserRepository;
-import com.supportsystem.application.response.dtos.UserResponseDTO;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class AppUserServiceImpl implements AppUserService, UserDetailsService {  // Implement UserDetailsService
 
-    @Autowired
-    private AppUserRepository userRepository;
-
-    private ModelMapper modelMapper = new ModelMapper();
-
-    @Autowired
-    private RoleRepository roleRepository;
+    private final AppUserRepository userRepository;
+    private final ModelMapper modelMapper;
 
     @Override
     @Transactional

--- a/src/main/java/com/supportsystem/application/services/RoleServiceImpl.java
+++ b/src/main/java/com/supportsystem/application/services/RoleServiceImpl.java
@@ -2,16 +2,16 @@ package com.supportsystem.application.services;
 
 import com.supportsystem.application.domains.Role;
 import com.supportsystem.application.repositories.RoleRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class RoleServiceImpl implements RoleService {
 
-    @Autowired
-    private RoleRepository roleRepository;
+    private final RoleRepository roleRepository;
 
     @Override
     public Role createRole(String roleName) {

--- a/src/main/java/com/supportsystem/application/services/TicketCommentServiceImpl.java
+++ b/src/main/java/com/supportsystem/application/services/TicketCommentServiceImpl.java
@@ -1,30 +1,21 @@
 package com.supportsystem.application.services;
 
+import com.supportsystem.application.exceptions.ResourceNotFoundException;
+import com.supportsystem.application.repositories.TicketCommentRepository;
+import com.supportsystem.application.response.dtos.TicketCommentResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.supportsystem.application.exceptions.ResourceNotFoundException;
-import org.modelmapper.ModelMapper;
-import org.modelmapper.convention.MatchingStrategies;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import com.supportsystem.application.repositories.TicketCommentRepository;
-import com.supportsystem.application.response.dtos.TicketCommentResponseDTO;
-
 @Service
+@RequiredArgsConstructor
 public class TicketCommentServiceImpl implements TicketCommentService {
 
-	private TicketCommentRepository ticketCommentRepository;
-
+	private final TicketCommentRepository ticketCommentRepository;
     private final ModelMapper modelMapper;
-
-    @Autowired
-    public TicketCommentServiceImpl(TicketCommentRepository ticketCommentRepository, ModelMapper modelMapper) {
-        this.ticketCommentRepository = ticketCommentRepository;
-        this.modelMapper = modelMapper;
-        this.modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
-    }
 
     @Override
     public List<TicketCommentResponseDTO> getAllTicketCommentsByTicketId(Long ticketId) {

--- a/src/main/java/com/supportsystem/application/services/TicketServiceImpl.java
+++ b/src/main/java/com/supportsystem/application/services/TicketServiceImpl.java
@@ -1,19 +1,19 @@
 package com.supportsystem.application.services;
 
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
-
+import com.supportsystem.application.domains.Ticket;
 import com.supportsystem.application.exceptions.ResourceNotFoundException;
+import com.supportsystem.application.repositories.TicketRepository;
+import com.supportsystem.application.request.dtos.TicketRequestDTO;
+import com.supportsystem.application.response.dtos.TicketResponseDTO;
+import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.supportsystem.application.domains.Ticket;
-import com.supportsystem.application.repositories.TicketRepository;
-import com.supportsystem.application.response.dtos.TicketResponseDTO;
-import com.supportsystem.application.request.dtos.TicketRequestDTO;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class TicketServiceImpl implements TicketService {

--- a/src/main/java/com/supportsystem/application/services/UserRegistrationServiceImpl.java
+++ b/src/main/java/com/supportsystem/application/services/UserRegistrationServiceImpl.java
@@ -4,7 +4,7 @@ import com.supportsystem.application.domains.AppUser;
 import com.supportsystem.application.domains.Role;
 import com.supportsystem.application.repositories.AppUserRepository;
 import com.supportsystem.application.repositories.RoleRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -12,16 +12,12 @@ import java.util.Collections;
 
 
 @Service
+@RequiredArgsConstructor
 public class UserRegistrationServiceImpl implements UserRegistrationService {
 
-    @Autowired
-    private AppUserRepository userRepository;
-
-    @Autowired
-    private RoleRepository roleRepository;
-
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    private final AppUserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
 
 
     public AppUser registerUser(String username, String password, String email) {

--- a/src/test/java/com/supportsystem/application/services/TicketServiceImplTest.java
+++ b/src/test/java/com/supportsystem/application/services/TicketServiceImplTest.java
@@ -10,9 +10,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -70,7 +72,6 @@ public class TicketServiceImplTest {
 
     @BeforeEach
     public void setUp() {
-        // Manually initialize the ModelMapper here
         ticketService = new TicketServiceImpl(ticketRepository, new ModelMapper());
     }
 

--- a/src/test/java/com/supportsystem/application/services/UserServiceImplTest.java
+++ b/src/test/java/com/supportsystem/application/services/UserServiceImplTest.java
@@ -8,11 +8,13 @@ import com.supportsystem.application.request.dtos.UserRequestDTO;
 import com.supportsystem.application.response.dtos.UserResponseDTO;
 import com.supportsystem.application.shared.Status;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.*;
@@ -95,11 +97,14 @@ public class UserServiceImplTest {
 	}
 
 	@Mock
-	@Autowired
 	private AppUserRepository appUserRepository;
 
-	@InjectMocks
 	private AppUserServiceImpl appUserService;
+
+    @BeforeEach
+    public void setUp() {
+        appUserService = new AppUserServiceImpl(appUserRepository, new ModelMapper());
+    }
 
 	@Test
 	public void testGetAllUsers() {


### PR DESCRIPTION
For https://github.com/januschung/support-system-server/issues/40

Advantages of Using @RequiredArgsConstructor

Immutable Dependencies:
@RequiredArgsConstructor creates a constructor that initializes all final fields. Marking dependencies as final ensures they are immutable, making the class inherently thread-safe.

Explicit Dependency Injection:
Constructor-based injection (via @RequiredArgsConstructor) is generally preferred over field injection (@Autowired) because it makes dependencies more explicit and testable.

Null-Safety at Construction:
With constructor injection, you ensure dependencies are always set when the object is created, reducing the risk of 
NullPointerException.

Simpler Testing:
Constructor injection simplifies testing because you can instantiate the class and provide mock dependencies directly in unit tests without requiring Spring to wire up beans.

Reduced Boilerplate:
Using @RequiredArgsConstructor eliminates the need to write or annotate the constructor manually.

Alignment with Modern Practices:
Constructor-based injection aligns with Spring's current best practices and promotes a more functional programming style.
